### PR TITLE
Added mapping to existing object

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,14 @@ Mapper.AddMap<Customer, CustomerInput>(src =>
     return res;
 });
 ```
+``` ruby
+Mapper.AddMap<Customer, CustomerInput>((src, target, tag)  =>
+{
+    target.InjectFrom(src); // maps properties with same name and type
+    target.FullName = src.FirstName + " " + src.LastName;
+    return target;
+});
+```
 ####InjectFrom
 `InjectFrom<TInjection>(source)` is used to map using a convention, when `TInjection` is not specified it will map properties with exact same name and type
 

--- a/README.md
+++ b/README.md
@@ -70,11 +70,10 @@ you can use `FlatLoopInjection` and `UnflatLoopInjection` directly or inherit th
 By default `Mapper.Map` will only map properties with the exact same name and type, this can be changed by setting `Mapper.DefaultMap`, here's an example:
 
 ``` ruby
-    Mapper.DefaultMap = (src, resType, tag) =>
+    Mapper.DefaultMap = (src, target, tag) =>
     {
-        var res = Activator.CreateInstance(resType);
-        res.InjectFrom(src);
-        return res;
+        target.InjectFrom(src);
+        return target;
     };
 ```
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,11 @@ var customerInput = Mapper.Map<Customer, CustomerInput>(customer);
 ```
 (useful when working with EF proxy objects)
 
+You can also map an existing object:
+``` ruby
+var target = new CustomerInput();
+var customerInput = Mapper.Map<Customer, CustomerInput>(customer, target); 
+```
 by default it will only map properties with the exact same name and type (this can be changed)
 
 ####custom maps 

--- a/Tests/MapperTests.cs
+++ b/Tests/MapperTests.cs
@@ -31,7 +31,7 @@ namespace Tests
                 {
                     var res = new CustomerInput();
                     res.InjectFrom(src);
-                    
+
                     //res.RegDate = src.RegDate.ToShortDateString();
                     //res.RegDate = src.RegDate.tos;
                     //res.FirstName = src.FirstName;
@@ -39,7 +39,7 @@ namespace Tests
                     //res.Id = src.Id;
                     return res;
                 });
-            
+
             var w = new Stopwatch();
 
             w.Start();
@@ -112,7 +112,7 @@ namespace Tests
             var ci2 = Mapper.Map<CustomerInput>(new { RegDate = DateTime.Now });
             Assert.IsNull(ci2.RegDate);
         }
-       
+
         [Test]
         public void ShouldUseTag()
         {
@@ -212,7 +212,7 @@ namespace Tests
             var customerProxy = new CustomerProxy { FirstName = "c1", ProxyName = "proxy1", RegDate = DateTime.Now };
 
             Mapper.AddMap<Customer, CustomerInput>(src =>
-                { 
+                {
                     var res = new CustomerInput();
                     res.InjectFrom(src);
                     res.RegDate = src.RegDate.ToShortDateString();
@@ -223,6 +223,25 @@ namespace Tests
 
             Assert.AreEqual(customerProxy.RegDate.ToShortDateString(), input.RegDate);
             Assert.AreEqual(customerProxy.FirstName, input.FirstName);
+        }
+
+        [Test]
+        public void ShouldMapWithExistingObject()
+        {
+            var existingCustomer = new Customer { Id = 1, FirstName = "c1", LastName = "lnc1", RegDate = DateTime.Parse("02/01/2015") };
+            var customerToMap = new CustomerDifferent { CustomerId = 2, FirstName = "c2", LastName = "lnc1", RegDate = DateTime.Now };
+                        
+            Mapper.AddMap<CustomerDifferent, Customer>((src, target, tag) =>
+            {
+                target.InjectFrom(src);
+                target.Id = src.CustomerId;
+                return target;
+            });
+
+            existingCustomer = Mapper.Map(customerToMap, existingCustomer);
+
+            Assert.AreEqual(existingCustomer.Id, customerToMap.CustomerId);
+            Assert.AreEqual(existingCustomer.RegDate, customerToMap.RegDate);
         }
 
         private static Customer GetCustomer()

--- a/Tests/SampleTypes/CustomerDifferent.cs
+++ b/Tests/SampleTypes/CustomerDifferent.cs
@@ -1,0 +1,25 @@
+﻿using System;
+
+namespace Tests.SampleTypes
+{
+    public class CustomerDifferent
+    {
+        public int CustomerId { get; set; }
+
+        public string FirstName { get; set; }
+
+        public string LastName { get; set; }
+
+        public DateTime RegDate { get; set; }
+
+        public string Prop1 { get; set; }
+
+        public string Prop2
+        {
+            set
+            {
+                FirstName = value;
+            }
+        }
+    }
+}

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -90,6 +90,7 @@
     <Compile Include="KnownTargetValueInjectionTest.cs" />
     <Compile Include="NullableInjectionsTests.cs" />
     <Compile Include="SampleTypes\CountryDto.cs" />
+    <Compile Include="SampleTypes\CustomerDifferent.cs" />
     <Compile Include="SampleTypes\Customer.cs" />
     <Compile Include="SampleTypes\CustomerInput.cs" />
     <Compile Include="SampleTypes\CustomerProxy.cs" />
@@ -126,6 +127,9 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/ValueInjecter/Mapper.cs
+++ b/ValueInjecter/Mapper.cs
@@ -45,12 +45,32 @@ namespace Omu.ValueInjecter
             return (TResult)DefaultMap(source, typeof(TResult), tag);
         }
 
+        public static TResult Map<TSource, TResult>(TSource source, TResult target, object tag = null)
+        {
+            Tuple<object, bool> funct;
+            Maps.TryGetValue(new Tuple<Type, Type>(typeof(TSource), typeof(TResult)), out funct);
+
+            if (funct != null)
+            {
+                if (funct.Item2)
+                    return ((Func<TSource, TResult, object, TResult>)funct.Item1)(source, target, tag);
+                return ((Func<TSource, TResult, TResult>)funct.Item1)(source, target);
+            }
+            
+            return (TResult)DefaultMap(source, typeof(TResult), tag);
+        }
+
         public static void AddMap<TSource, TResult>(Func<TSource, TResult> func)
         {
             Maps.AddOrUpdate(new Tuple<Type, Type>(typeof(TSource), typeof(TResult)), new Tuple<object, bool>(func, false), (key, oldValue) => new Tuple<object, bool>(func, false));
         }
 
         public static void AddMap<TSource, TResult>(Func<TSource, object, TResult> func)
+        {
+            Maps.AddOrUpdate(new Tuple<Type, Type>(typeof(TSource), typeof(TResult)), new Tuple<object, bool>(func, true), (key, oldValue) => new Tuple<object, bool>(func, true));
+        }
+
+        public static void AddMap<TSource, TResult>(Func<TSource, TResult, object, TResult> func)
         {
             Maps.AddOrUpdate(new Tuple<Type, Type>(typeof(TSource), typeof(TResult)), new Tuple<object, bool>(func, true), (key, oldValue) => new Tuple<object, bool>(func, true));
         }


### PR DESCRIPTION
I added the possibility to map an existing target object with a source object. 
I also updated the default mapper so that it will work with an existing object. 
Included test methods.
