### PR TITLE
Allow flattening/unflattening using source object properties

### DIFF
--- a/Tests/FlatLoopInjectionTests.cs
+++ b/Tests/FlatLoopInjectionTests.cs
@@ -95,5 +95,26 @@ namespace Tests
             flat.Parentb.IsEqualTo("True");
             flat.Bool.IsEqualTo(null);
         }
+
+        [Test]
+        public void ObjectFlatTest()
+        {
+            var f = new
+            {
+                Parent = (object)new Foo
+                {
+                    _a = "aaa",
+                    a = 23,
+                    b = true,
+                    Name = "v"
+                }
+            };
+
+            var flat = new Flat();
+
+            flat.InjectFrom<FlatBoolToString>(f);
+            flat.Parentb.IsEqualTo("True");
+            flat.Bool.IsEqualTo(null);
+        }
     }
 }

--- a/Tests/UberFlatterTests.cs
+++ b/Tests/UberFlatterTests.cs
@@ -103,12 +103,26 @@ namespace Tests
         }
 
         [Test]
+        public void GetTrailsByObject()
+        {
+            var l = TrailFinder.GetTrails("TheFooBarName", new Unflat(), Match, StringComparison.Ordinal).ToList();
+            l.Count.IsEqualTo(2);
+        }
+
+        [Test]
         public void GetAllTrails()
         {
             var l = TrailFinder.GetTrails("The2FooBarName", typeof(Unflat).GetProperties(), Match, StringComparison.Ordinal);
             l.Count().IsEqualTo(2);
         }
-        
+
+        [Test]
+        public void GetAllTrailsByObject()
+        {
+            var l = TrailFinder.GetTrails("The2FooBarName", new Unflat(), Match, StringComparison.Ordinal);
+            l.Count().IsEqualTo(2);
+        }
+
         [Test]
         public void Speed()
         {

--- a/Tests/UnflatLoopInjectionTests.cs
+++ b/Tests/UnflatLoopInjectionTests.cs
@@ -48,11 +48,21 @@ namespace Tests
         [Test]
         public void GenericUnflatTest()
         {
-            var flat = new  { FooBarNumber = "123" };
+            var flat = new { FooBarNumber = "123" };
             var foo = new UnflatType();
 
             foo.InjectFrom<StrToIntUnflat>(flat);
             Assert.AreEqual(123, foo.Foo.Bar.Number);
+        }
+
+        [Test]
+        public void ObjectUnflatTest()
+        {
+            var flat = (object)new { FooBarNumber = "123" };
+            var foo = new UnflatType();
+
+            foo.InjectFrom<StrToIntUnflat>(flat);
+            Assert.AreEqual(123, (foo.Foo as Foo).Bar.Number);
         }
 
         public class FlatType

--- a/ValueInjecter-Universal/Flat/TrailFinder.cs
+++ b/ValueInjecter-Universal/Flat/TrailFinder.cs
@@ -25,11 +25,33 @@ namespace Omu.ValueInjecter.Flat
             StringComparison comparison,
             bool forFlattening = true)
         {
-            return lookupProps.SelectMany(lookupProp => GetTrailsForProperty(flatPropertyName, lookupProp, match, comparison, forFlattening));
+            object lookupObject = null;
+            return lookupProps.SelectMany(lookupProp => GetTrailsForProperty(flatPropertyName, lookupObject, lookupProp, match, comparison, forFlattening));
+        }
+
+        /// <summary>
+        /// Get all possible trails based on the property name
+        /// </summary>
+        /// <param name="flatPropertyName">flat property name</param>
+        /// <param name="lookupObject">object whose properties to look into</param>
+        /// <param name="match">match func used for checking the last property in the trail</param>
+        /// <param name="comparison">StringComparison type used for building the flat trail</param>
+        /// <param name="forFlattening">getting trails for flattening or unflattening, in the first case we need to make sure the properties are readable in the latter writeable</param>
+        /// <returns>all possible trails</returns>
+        public static IEnumerable<IList<string>> GetTrails(
+            string flatPropertyName,
+            object lookupObject,
+            Func<string, PropertyInfo, bool> match,
+            StringComparison comparison,
+            bool forFlattening = true)
+        {
+            var lookupProps = lookupObject.GetProps();
+            return lookupProps.SelectMany(lookupProp => GetTrailsForProperty(flatPropertyName, lookupObject, lookupProp, match, comparison, forFlattening));
         }
 
         private static IEnumerable<IList<string>> GetTrailsForProperty(
             string flatPropName, 
+            object lookupObject,
             PropertyInfo lookupProp, 
             Func<string, PropertyInfo, bool> match,
             StringComparison comparison, 
@@ -49,9 +71,18 @@ namespace Omu.ValueInjecter.Flat
 
             if (flatPropName.StartsWith(lookupProp.Name, comparison))
             {
-                foreach (var pro in lookupProp.PropertyType.GetProps())
+                if (lookupObject != null)
                 {
-                    foreach (var trail in GetTrailsForProperty(StrUtil.RemovePrefix(flatPropName, lookupProp.Name, comparison), pro, match, comparison, forFlattening))
+                    lookupObject = lookupProp.GetValue(lookupObject);
+                }
+
+                var props = lookupObject == null
+                    ? lookupProp.PropertyType.GetProps()
+                    : lookupObject.GetProps();
+
+                foreach (var pro in props)
+                {
+                    foreach (var trail in GetTrailsForProperty(StrUtil.RemovePrefix(flatPropName, lookupProp.Name, comparison), lookupObject, pro, match, comparison, forFlattening))
                     {
                         if (trail != null)
                         {

--- a/ValueInjecter-Universal/Flat/UberFlatter.cs
+++ b/ValueInjecter-Universal/Flat/UberFlatter.cs
@@ -27,7 +27,7 @@ namespace Omu.ValueInjecter.Flat
         /// <returns>all matching unflat targets info</returns>
         public static IEnumerable<PropertyWithComponent> Unflat(string flatPropertyName, object lookupObject, Func<string, PropertyInfo, bool> match, StringComparison comparison, Func<PropertyInfo, object, object> activator = null)
         {
-            var trails = TrailFinder.GetTrails(flatPropertyName, lookupObject.GetType().GetProps(), match, comparison, false).Where(o => o != null);
+            var trails = TrailFinder.GetTrails(flatPropertyName, lookupObject, match, comparison, false).Where(o => o != null);
 
             return trails.Select(trail => Tunnelier.Digg(trail, lookupObject, activator));
         }
@@ -79,7 +79,7 @@ namespace Omu.ValueInjecter.Flat
         /// <returns>all matching unflat targets info</returns>
         public static IEnumerable<PropertyWithComponent> Flat(string flatPropertyName, object lookupObject, Func<string, PropertyInfo, bool> match, StringComparison comparison)
         {
-            var trails = TrailFinder.GetTrails(flatPropertyName, lookupObject.GetType().GetProps(), match, comparison).Where(o => o != null);
+            var trails = TrailFinder.GetTrails(flatPropertyName, lookupObject, match, comparison).Where(o => o != null);
 
             return trails.Select(trail => Tunnelier.Find(trail, lookupObject));
         }

--- a/ValueInjecter/Flat/TrailFinder.cs
+++ b/ValueInjecter/Flat/TrailFinder.cs
@@ -28,11 +28,33 @@ namespace Omu.ValueInjecter.Flat
             StringComparison comparison,
             bool forFlattening = true)
         {
-            return lookupProps.SelectMany(lookupProp => GetTrailsForProperty(flatPropertyName, lookupProp, match, comparison, forFlattening));
+            object lookupObject = null;
+            return lookupProps.SelectMany(lookupProp => GetTrailsForProperty(flatPropertyName, lookupObject, lookupProp, match, comparison, forFlattening));
+        }
+
+        /// <summary>
+        /// Get all possible trails based on the property name
+        /// </summary>
+        /// <param name="flatPropertyName">flat property name</param>
+        /// <param name="lookupObject">object whose properties to look into</param>
+        /// <param name="match">match func used for checking the last property in the trail</param>
+        /// <param name="comparison">StringComparison type used for building the flat trail</param>
+        /// <param name="forFlattening">getting trails for flattening or unflattening, in the first case we need to make sure the properties are readable in the latter writeable</param>
+        /// <returns>all possible trails</returns>
+        public static IEnumerable<IList<string>> GetTrails(
+            string flatPropertyName,
+            object lookupObject,
+            Func<string, PropertyInfo, bool> match,
+            StringComparison comparison,
+            bool forFlattening = true)
+        {
+            var lookupProps = lookupObject.GetProps();
+            return lookupProps.SelectMany(lookupProp => GetTrailsForProperty(flatPropertyName, lookupObject, lookupProp, match, comparison, forFlattening));
         }
 
         private static IEnumerable<IList<string>> GetTrailsForProperty(
             string flatPropName, 
+            object lookupObject,
             PropertyInfo lookupProp, 
             Func<string, PropertyInfo, bool> match,
             StringComparison comparison, 
@@ -52,9 +74,18 @@ namespace Omu.ValueInjecter.Flat
 
             if (flatPropName.StartsWith(lookupProp.Name, comparison))
             {
-                foreach (var pro in lookupProp.PropertyType.GetProps())
+                if (lookupObject != null)
                 {
-                    foreach (var trail in GetTrailsForProperty(StrUtil.RemovePrefix(flatPropName, lookupProp.Name, comparison), pro, match, comparison, forFlattening))
+                    lookupObject = lookupProp.GetValue(lookupObject);
+                }
+
+                var props = lookupObject == null
+                    ? lookupProp.PropertyType.GetProps()
+                    : lookupObject.GetProps();
+
+                foreach (var pro in props)
+                {
+                    foreach (var trail in GetTrailsForProperty(StrUtil.RemovePrefix(flatPropName, lookupProp.Name, comparison), lookupObject, pro, match, comparison, forFlattening))
                     {
                         if (trail != null)
                         {

--- a/ValueInjecter/Flat/UberFlatter.cs
+++ b/ValueInjecter/Flat/UberFlatter.cs
@@ -27,7 +27,7 @@ namespace Omu.ValueInjecter.Flat
         /// <returns>all matching unflat targets info</returns>
         public static IEnumerable<PropertyWithComponent> Unflat(string flatPropertyName, object lookupObject, Func<string, PropertyInfo, bool> match, StringComparison comparison, Func<PropertyInfo, object, object> activator = null)
         {
-            var trails = TrailFinder.GetTrails(flatPropertyName, lookupObject.GetType().GetProps(), match, comparison, false).Where(o => o != null);
+            var trails = TrailFinder.GetTrails(flatPropertyName, lookupObject, match, comparison, false).Where(o => o != null);
 
             return trails.Select(trail => Tunnelier.Digg(trail, lookupObject, activator));
         }
@@ -79,7 +79,7 @@ namespace Omu.ValueInjecter.Flat
         /// <returns>all matching unflat targets info</returns>
         public static IEnumerable<PropertyWithComponent> Flat(string flatPropertyName, object lookupObject, Func<string, PropertyInfo, bool> match, StringComparison comparison)
         {
-            var trails = TrailFinder.GetTrails(flatPropertyName, lookupObject.GetType().GetProps(), match, comparison).Where(o => o != null);
+            var trails = TrailFinder.GetTrails(flatPropertyName, lookupObject, match, comparison).Where(o => o != null);
 
             return trails.Select(trail => Tunnelier.Find(trail, lookupObject));
         }


### PR DESCRIPTION
I came across a situation where flattening didn't work if the source property type was an object. It also didn't flatten derived type properties if the property value was a derived type of the property type. This PR will update UberFlatter to allow flattening/unflattening using the type of source object property values and fall back to source type properties when the source property has no value.